### PR TITLE
changed ContextManager to subclass and added props

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 setup(
   name = 'async-mock',
-  version = '1.0.2',
+  version = '1.0.3',
   description = 'asyncio mocker builder library',
   author = 'Christopher Brichford',
   author_email = 'chrisb@farmersbusinessnetwork.com',


### PR DESCRIPTION
ContextManager class now is a subclass of MagicMock as
opposed to taking a MagicMock object in constructor.

Also added the setProperty method, allowing simulation of
properties on mocked objects.
